### PR TITLE
Switch from v3 to v5 of the auto-pr creator

### DIFF
--- a/.github/workflows/upstream-refresh.yaml
+++ b/.github/workflows/upstream-refresh.yaml
@@ -80,7 +80,7 @@ jobs:
           # Remove the release tar.gz
           rm $RELEASE_TAG
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Upgrade ensmallen to ${{ steps.ensmallen-lib.outputs.release_tag }}
           title: Upgrade ensmallen to ${{ steps.ensmallen-lib.outputs.release_tag }}


### PR DESCRIPTION
Address github action issue: 

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, peter-evans/create-pull-request@v3. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default 
 